### PR TITLE
Makefile: compile program with gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+OBJS = bslv_algs.o bslv_lists.o bslv_lp.o bslv_main.o bslv_poly.o bslv_vlp.o
+
+all:	bensolve
+
+bensolve:	$(OBJS)
+	gcc -o $@ $^ -lm -lglpk
+
+%.o:	%.c %.h
+	gcc -std=c99 -c $<


### PR DESCRIPTION
So far it does not contain the dependencies between the modules,
thus on recompilation some modules may be ignored that should be recompiled.
